### PR TITLE
Fix CPF/CNPJ mask regex

### DIFF
--- a/js/cadastro.js
+++ b/js/cadastro.js
@@ -37,7 +37,7 @@ function aplicarMascaraCpfCnpj(input) {
       valor = valor.replace(/(\d{3})(\d{1,2})$/, "$1-$2");
     } else {
       valor = valor.replace(/^(\d{2})(\d)/, "$1.$2");
-      valor = valor.replace(/^(\\d{2})\.(\\d{3})(\\d)/, "$1.$2.$3");
+      valor = valor.replace(/^(\d{2})\.(\d{3})(\d)/, "$1.$2.$3");
       valor = valor.replace(/\.(\d{3})(\d)/, ".$1/$2");
       valor = valor.replace(/(\d{4})(\d)/, "$1-$2");
     }


### PR DESCRIPTION
## Summary
- fix regex in cadastro.js that broke CPF/CNPJ masking

## Testing
- `npm test` *(fails: Could not read package.json)*