### PR TITLE
Add Jest setup and tests for CPF/CNPJ mask

### DIFF
--- a/js/cadastro.js
+++ b/js/cadastro.js
@@ -49,3 +49,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const campo = document.querySelector('input[name="cpfcnpj"]');
   if (campo) aplicarMascaraCpfCnpj(campo);
 });
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { aplicarMascaraCpfCnpj };
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "leal-site-tests",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "devDependencies": {
     "jest": "^29.0.0",

--- a/tests/js/cadastro.test.js
+++ b/tests/js/cadastro.test.js
@@ -1,0 +1,23 @@
+/**
+ * @jest-environment jsdom
+ */
+
+const { aplicarMascaraCpfCnpj } = require('../../js/cadastro');
+
+describe('aplicarMascaraCpfCnpj', () => {
+  test('formata CPF com 11 dígitos', () => {
+    const input = document.createElement('input');
+    aplicarMascaraCpfCnpj(input);
+    input.value = '00000000000';
+    input.dispatchEvent(new Event('input'));
+    expect(input.value).toBe('000.000.000-00');
+  });
+
+  test('formata CNPJ com 14 dígitos', () => {
+    const input = document.createElement('input');
+    aplicarMascaraCpfCnpj(input);
+    input.value = '00000000000000';
+    input.dispatchEvent(new Event('input'));
+    expect(input.value).toBe('00.000.000/0000-00');
+  });
+});


### PR DESCRIPTION
## Summary
- export `aplicarMascaraCpfCnpj` for testing
- add tests for CPF and CNPJ formatting
- expose a watch mode for Jest

## Testing
- `npm test` *(fails: jest not found)*